### PR TITLE
Fix double loading issues when loading examples

### DIFF
--- a/public/js/controllers.js
+++ b/public/js/controllers.js
@@ -128,7 +128,6 @@ angular.module('jqplay.controllers', []).controller('JqplayCtrl', function Jqpla
   $scope.loadSample = function(samples, index) {
     $scope.jq.j = samples[index].input_j;
     $scope.jq.q = samples[index].input_q;
-    $scope.run($scope.jq);
+    $scope.input.$valid = true;
   };
-
 });


### PR DESCRIPTION
The problem was due to `$scope.input.$valid` is not set properly. The solution
is to hard set it in load sample.

/cc @leoping
