### PR TITLE
Kill running process for timeout execution

### DIFF
--- a/jq/jq_test.go
+++ b/jq/jq_test.go
@@ -1,0 +1,39 @@
+package jq
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestJQEval(t *testing.T) {
+	pwd, _ := os.Getwd()
+	err := SetPath(filepath.Join(pwd, ".."))
+	if err != nil {
+		t.Fatalf("can't set JQ path: %s", err)
+	}
+
+	jq := &JQ{}
+	_, err = jq.Eval()
+
+	if err == nil {
+		t.Errorf("err should not be nil since it's invalid input")
+	}
+
+	jq = &JQ{J: "{}", Q: "def foo: foo; foo"}
+	_, err = jq.Eval()
+
+	if err == nil {
+		t.Errorf("err should not be nil since the executation should timeout")
+	}
+
+	jq = &JQ{
+		J: `{ "foo": { "bar": { "baz": 123 } } }`,
+		Q: ".",
+	}
+	_, err = jq.Eval()
+
+	if err != nil {
+		t.Errorf("err should be nil: %s", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,11 @@ import (
 )
 
 func main() {
+	err := jq.Init()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	log.Printf("jq version=%s path=%s\n", jq.Version, jq.Path)
 
 	port := os.Getenv("PORT")

--- a/server/handler.go
+++ b/server/handler.go
@@ -60,11 +60,6 @@ func (h *JQHandler) handleJq(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := jq.Validate(); err != nil {
-		h.r.JSON(rw, 422, map[string]string{"message": err.Error()})
-		return
-	}
-
 	re, err := jq.Eval()
 	if err != nil {
 		h.r.JSON(rw, 422, map[string]string{"message": err.Error()})


### PR DESCRIPTION
The child process for running `jq` query wasn’t killed for timeout execution,
taking up resource even if the server has responded.
