### PR TITLE
play.jqlang.org branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# jqplay
+# playground
 
 A [jq](https://jqlang.github.io/jq) playground built with [Next.js](https://nextjs.org).
 Test your jq queries against JSON directly in your browser. All jq queries and HTTP requests to fetch JSON are processed **locally** in your browser. Snippets are sent to the server **only** if you choose to share them.
 
-✨ **Try it out at [jqplay.org](https://jqplay.org)!**
+✨ **Try it out at [play.jqlang.org](https://play.jqlang.org)!**
 
 ## How It Works
 
-- **WebAssembly-Powered**: jqplay integrates the [jq-wasm](https://github.com/owenthereal/jq-wasm) package, a WebAssembly-based jq JSON processor for Node.js and browsers, with no native dependencies. This ensures that all jq queries run directly in your browser.
+- **WebAssembly-Powered**: it integrates the [jq-wasm](https://github.com/owenthereal/jq-wasm) package, a WebAssembly-based jq JSON processor for Node.js and browsers, with no native dependencies. This ensures that all jq queries run directly in your browser.
 - **Local Data Processing**: Your JSON input is processed locally in your browser, ensuring your data stays private and secure.
 - **Shareable Snippets**: If you share your jq query, a unique URL is generated on the server. Others can open the shared snippet, but the query will still run locally in their browser.
 
@@ -24,8 +24,8 @@ Prerequisites
 ### 1. Clone the repository
 
 ```console
-git clone https://github.com/owenthereal/jqplay
-cd jqplay
+git clone https://github.com/jqlang/playground
+cd playground
 ```
 
 ### 2. Start in Development Mode
@@ -36,7 +36,7 @@ To start the app in development mode with hot reload enabled and a local Postgre
 docker compose up
 ```
 
-Open your browser to <http://localhost:3000> to explore jqplay.
+Open your browser to <http://localhost:3000> to explore the playground.
 
 ### 3. Run a Production Build
 
@@ -47,7 +47,7 @@ npm run build
 npm run start
 ```
 
-Open your browser to <http://localhost:3000> to use jqplay locally in production mode.
+Open your browser to <http://localhost:3000> to use playground locally in production mode.
 
 ## Contributing
 
@@ -55,7 +55,7 @@ Contributions are welcome! 🎉 Whether you’re fixing bugs, adding features, o
 
 ## License
 
-📜 jqplay is licensed under the [MIT License](LICENSE).
+📜 The jq playground is licensed under the [MIT License](LICENSE).
 
 ---
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { Inter } from 'next/font/google';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
-  title: 'jqplay',
+  title: 'jq playground',
   description: 'A playground for jq',
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { AppBar, Toolbar, IconButton, Box, Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material';
-import { Brightness4, Brightness7, ContentCopy, Help, Share, VolunteerActivism } from '@mui/icons-material';
+import { Brightness4, Brightness7, ContentCopy, GitHub, Help, Share, VolunteerActivism } from '@mui/icons-material';
 import { MouseEvent, useState } from 'react';
 import Link from 'next/link';
 import { useDarkMode } from './ThemeProvider';
@@ -88,10 +88,10 @@ const Header: React.FC<HeaderProps> = ({ onShare, onExampleClick, onCopyClick, e
                             <Share />
                         </IconButton>
                     </Tooltip>
-                    <Tooltip title="Sponsor">
-                        <IconButton color="inherit" aria-label="Sponsor">
-                            <Link href="https://github.com/sponsors/owenthereal" passHref>
-                                <VolunteerActivism />
+                    <Tooltip title="Source">
+                        <IconButton color="inherit" aria-label="Source">
+                            <Link href="https://github.com/jqlang/playground" passHref target='_blank'>
+                                <GitHub />
                             </Link>
                         </IconButton>
                     </Tooltip>

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -273,11 +273,11 @@ function PlaygroundElement({ input, initialNotification }: PlaygroundProps) {
                 </Grid>
                 <Box sx={{ textAlign: 'center' }}>
                     <Typography variant="body1" sx={{ color: 'text.secondary' }}>
-                        jqplay is open-source and licensed under the MIT license.<br />
+                        jq playground is open-source and licensed under the MIT license.<br />
                         All jq queries and HTTP requests to fetch JSON are processed locally in your browser.<br />
                         Snippets are only sent to the server when you choose to share them.<br />
                         View the&nbsp;
-                        <Link href="https://github.com/owenthereal/jqplay" style={{ textDecoration: 'none', color: 'inherit' }}>
+                        <Link href="https://github.com/jqlang/playground" style={{ textDecoration: 'none', color: 'inherit' }}>
                             source code
                         </Link>
                         &nbsp;on GitHub.


### PR DESCRIPTION
Rebrand jqplay.org to play.jqlang.org