### PR TITLE
Bump jq-wasm to 1.1.0-jq-1.7.jq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "^6.3.1",
         "@prisma/client": "^6.3.1",
         "@sentry/nextjs": "^9.1.0",
-        "jq-wasm": "^1.0.1",
+        "jq-wasm": "^1.1.0-jq-1.7.1",
         "next": "15.2.3",
         "pg": "^8.13.3",
         "prisma": "^6.1.0",
@@ -6431,9 +6431,9 @@
       }
     },
     "node_modules/jq-wasm": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jq-wasm/-/jq-wasm-1.0.1.tgz",
-      "integrity": "sha512-E4WvOi44oDO5Ug6DF1B0WJhBFfXso+XD31MTo90SzcpNqPn1lweNeC2ndYJSBa2NRZQn2BOvzXhMaLcQnnkIFw==",
+      "version": "1.1.0-jq-1.7.1",
+      "resolved": "https://registry.npmjs.org/jq-wasm/-/jq-wasm-1.1.0-jq-1.7.1.tgz",
+      "integrity": "sha512-hShGjnN88Qgmjg2oBSX4UpVh/soUF4cQc3Rhg3C6rkMzmobgzEloTST7Ld1HnUIyxPygU1Hh4uW4M7ExRhDxGQ==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@mui/material": "^6.3.1",
     "@prisma/client": "^6.3.1",
     "@sentry/nextjs": "^9.1.0",
-    "jq-wasm": "^1.0.1",
+    "jq-wasm": "^1.1.0-jq-1.7.1",
     "next": "15.2.3",
     "pg": "^8.13.3",
     "prisma": "^6.1.0",

--- a/src/app/api/jq/route.ts
+++ b/src/app/api/jq/route.ts
@@ -1,8 +1,9 @@
-import jq from 'jq-wasm';
+import * as jq from 'jq-wasm';
 
 export async function GET(req: Request) {
     try {
-        const result = await jq.raw('{"foo":"bar"}', ".");
+        const { stdout, stderr } = await jq.raw('{"foo":"bar"}', ".");
+        const result = stdout + (stderr ? (stdout.length ? "\n" + stderr : stderr) : "");
         return new Response(result, { status: 200 });
     } catch (e: any) {
         const errorMessage = e?.message || 'An unknown error occurred';

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -2,8 +2,9 @@ import { HttpType } from './model';
 
 export const worker = {
     async jq(json: string, query: string, options?: Array<string> | null): Promise<string> {
-        const jq = await import('jq-wasm');
-        return jq.raw(json, query, options ?? undefined);
+        const jqModule = await import("jq-wasm");
+        const { stdout, stderr } = await jqModule.raw(json, query, options ?? undefined);
+        return stdout + (stderr ? (stdout.length ? "\n" + stderr : stderr) : "");
     },
 
     async http(


### PR DESCRIPTION
This version of the jq-wasm separates the stdout & stderr allowing client code to concat both output: https://github.com/owenthereal/jq-wasm/commit/6c303552c23369546f1b8f39c0e94d5200c46e87

This fixes https://github.com/jqlang/playground/issues/250.