### PR TITLE
Upgrade zod 3 -> 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react": "^19",
         "react-dom": "^19",
         "uuid": "^11.1.1",
-        "zod": "^3.23.8"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.20.0",
@@ -3685,15 +3685,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/@scalar/api-client/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@scalar/api-reference": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@scalar/api-reference/-/api-reference-1.60.0.tgz",
@@ -3965,15 +3956,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/types/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@scalar/use-codemirror": {
@@ -14118,9 +14100,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "^19",
     "react-dom": "^19",
     "uuid": "^11.1.1",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.20.0",

--- a/src/app/api/jq/route.ts
+++ b/src/app/api/jq/route.ts
@@ -27,7 +27,7 @@ function textResponse(text: string, status: number, headers?: Record<string, str
 
 function handleError(e: unknown): Response {
     if (e instanceof ZodError) {
-        const error: JqError = { error: e.errors };
+        const error: JqError = { error: e.issues };
         return jsonResponse(error, 422);
     }
 

--- a/src/app/api/snippets/[slug]/route.ts
+++ b/src/app/api/snippets/[slug]/route.ts
@@ -37,7 +37,7 @@ export async function GET(_: Request, { params }: PageProps): Promise<NextRespon
         Sentry.captureException(error, { extra: { slug } });
 
         if (error instanceof ZodError) {
-            const errorMessages = error.errors.map(e => e.message);
+            const errorMessages = error.issues.map(e => e.message);
             return NextResponse.json({ errors: errorMessages }, { status: 422 });
         }
         return NextResponse.json({ error: 'Server error' }, { status: 500 });

--- a/src/app/api/snippets/route.ts
+++ b/src/app/api/snippets/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request): Promise<NextResponse<SnippetCreateResp
 
         // Handle Zod validation errors
         if (error instanceof ZodError) {
-            const errorMessages = error.errors.map(e => e.message);
+            const errorMessages = error.issues.map(e => e.message);
             return NextResponse.json({ errors: errorMessages }, { status: 422 });
         }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,5 +13,5 @@ export function normalizeLineBreaks(text: string | undefined | null) {
 }
 
 export function prettifyZodError(error: ZodError) {
-    return error.errors.map(e => `${e.path.join(', ')} ${e.message}`.toLowerCase()).join(', ');
+    return error.issues.map(e => `${e.path.join(', ')} ${e.message}`.toLowerCase()).join(', ');
 }


### PR DESCRIPTION
## Summary

Upgrades zod to **4.4.3** (on Next 16 / React 19 from #340, #341). Third of the deferred majors.

## Changes
- `zod` `^3.23.8` → `^4.4.3`
- zod 4 renamed `ZodError.errors` → `ZodError.issues`; updated the 4 call sites:
  - `src/lib/utils.ts` (`prettifyZodError`)
  - `src/app/api/jq/route.ts`
  - `src/app/api/snippets/route.ts`
  - `src/app/api/snippets/[slug]/route.ts`

**No schema-definition changes.** `next-openapi-gen` parses the zod schema *source* via Babel AST (it doesn't run zod at runtime), so the generated `openapi.json` is identical — all 18 schema components intact. `z.string().url()` is kept as-is (deprecated-but-functional in zod 4, and recognized by the OpenAPI generator).

## Verification
- [x] `npm audit` → 0 vulnerabilities
- [x] `tsc --noEmit` → clean
- [x] `npm run lint` → clean
- [x] `npm test` → 77/77 pass
- [x] `npm run build` → succeeds; OpenAPI gen emits all 18 schema components
- [x] **Server-side zod** (`POST /api/jq`): valid → 200 (`.a` → `42`); invalid (missing `json`) → **422** with the zod 4 issue array (via `.issues`)
- [x] **Playwright**: client query `.a + 1` → `42` (0 console errors), `/api` docs render, mobile responsive

## Resolves
Dependabot #316 (zod → 4).

## Next in sequence
MUI 6 → 9, then tooling (Prisma 7 / TS 6 / eslint 10).