### PR TITLE
Upgrade TypeScript 5 -> 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "monaco-editor": "^0.55.1",
         "next-openapi-gen": "^0.9.4",
         "prisma": "^7.8.0",
-        "typescript": "^5",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.9"
       }
     },
@@ -13969,9 +13969,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "monaco-editor": "^0.55.1",
     "next-openapi-gen": "^0.9.4",
     "prisma": "^7.8.0",
-    "typescript": "^5",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Bumps **TypeScript 5 → 6.0.3**. The codebase type-checks cleanly under TS 6 — no code changes required.

## eslint 10 deferred (not in this PR)

This was meant to be "TypeScript 6 + eslint 10", but **eslint 10 is blocked upstream**: `eslint-config-next@16` bundles `eslint-plugin-react`, `eslint-plugin-import`, and `eslint-plugin-jsx-a11y`, and **none support eslint 10 even at their latest versions** (all peer-cap at `^9`). Installing eslint 10 hard-fails linting with `TypeError: scopeManager.addGlobals is not a function` (an eslint-9 internal removed in v10). No override fixes it — eslint 10 should wait until the Next/React eslint plugins ship eslint-10 support.

## Verification
- [x] `npm audit` → 0 vulnerabilities
- [x] `tsc --noEmit` → clean
- [x] `npm run lint` → clean (eslint 9; `typescript-eslint` parses TS 6 fine)
- [x] `npm test` → 77/77 pass
- [x] `npm run build` → succeeds

## Merge-order note
This PR and #344 (Prisma 7) both touch `package.json`/`package-lock.json` (independent in content) — merging one may require a trivial lockfile re-resolve on the other.