### PR TITLE
Bump next-openapi-gen to 1.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 
 # Generated Monaco editor files
 public/monaco-editor/
+
+# next-openapi-gen cache
+.openapi-gen/

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.9",
         "monaco-editor": "^0.55.1",
-        "next-openapi-gen": "^0.9.4",
+        "next-openapi-gen": "^1.4.3",
         "prisma": "^7.8.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
@@ -6209,6 +6209,19 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -6843,13 +6856,13 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6908,9 +6921,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8392,9 +8405,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8515,9 +8528,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9980,9 +9993,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10095,30 +10108,17 @@
       "license": "MIT"
     },
     "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11328,25 +11328,41 @@
       }
     },
     "node_modules/next-openapi-gen": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/next-openapi-gen/-/next-openapi-gen-0.9.4.tgz",
-      "integrity": "sha512-gmR1ONpGkB38GGjfer0cwtvwCBmIoP/3UtGWwb6D5kmULc2Gs7/JM5AhanLyyeUrPF2+3WtSR2nJZHi1VS05vg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/next-openapi-gen/-/next-openapi-gen-1.4.3.tgz",
+      "integrity": "sha512-NiccuEtolMeZsMVe0bkKU0E40ySgRoHOWYeGDOL50wJbmAHxfZsVO0c1mjZRekkH2kUh1ki55j2txPQYTsrLng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
-        "commander": "^14.0.0",
-        "fs-extra": "^11.3.1",
-        "js-yaml": "^4.1.0",
-        "ora": "^8.2.0"
+        "@babel/parser": "^7.29.2",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "commander": "^14.0.3",
+        "fs-extra": "^11.3.4",
+        "js-yaml": "^4.1.1",
+        "ora": "^9.3.0",
+        "typescript": "^5.9.3"
       },
       "bin": {
-        "next-openapi-gen": "dist/index.js"
+        "next-openapi-gen": "bin/cli.mjs",
+        "openapi-gen": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/next-openapi-gen/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/node-fetch": {
@@ -11553,24 +11569,23 @@
       }
     },
     "node_modules/ora": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
+        "chalk": "^5.6.2",
         "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
+        "cli-spinners": "^3.2.0",
         "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13214,9 +13229,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13259,29 +13274,21 @@
       }
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -13429,32 +13436,19 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -14797,6 +14791,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.9",
     "monaco-editor": "^0.55.1",
-    "next-openapi-gen": "^0.9.4",
+    "next-openapi-gen": "^1.4.3",
     "prisma": "^7.8.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -32,6 +32,74 @@
           "status"
         ]
       },
+      "HttpHeadersSchema": {
+        "type": "string",
+        "description": "HTTP headers as JSON object string (e.g., {\"Authorization\": \"Bearer token\"})"
+      },
+      "HttpMethodSchema": {
+        "type": "string",
+        "enum": [
+          "GET",
+          "POST",
+          "PUT",
+          "DELETE",
+          "PATCH",
+          "OPTIONS",
+          "HEAD"
+        ],
+        "description": "HTTP method"
+      },
+      "HttpRequestSchema": {
+        "type": "object",
+        "properties": {
+          "method": {
+            "$ref": "#/components/schemas/HttpMethodSchema"
+          },
+          "url": {
+            "$ref": "#/components/schemas/HttpUrlSchema"
+          },
+          "headers": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HttpHeadersSchema"
+              }
+            ]
+          },
+          "body": {
+            "type": "string",
+            "description": "HTTP request body"
+          }
+        },
+        "required": [
+          "method",
+          "url"
+        ]
+      },
+      "HttpUrlSchema": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to fetch JSON from"
+      },
+      "JqErrorSchema": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {}
+              }
+            ],
+            "description": "Error message or validation errors"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
       "JqQueryParamsSchema": {
         "type": "object",
         "properties": {
@@ -47,7 +115,6 @@
           },
           "options": {
             "type": "string",
-            "nullable": true,
             "description": "Comma-separated jq options: -c (compact), -n (null input), -R (raw input), -r (raw output), -s (slurp), -S (sort keys)",
             "example": "-r,-c"
           }
@@ -55,18 +122,6 @@
         "required": [
           "json",
           "query"
-        ]
-      },
-      "JqResponseSchema": {
-        "type": "object",
-        "properties": {
-          "result": {
-            "type": "string",
-            "description": "The jq query result"
-          }
-        },
-        "required": [
-          "result"
         ]
       },
       "JqRequestSchema": {
@@ -100,85 +155,7 @@
           "query"
         ]
       },
-      "SnippetPathParamsSchema": {
-        "type": "object",
-        "properties": {
-          "slug": {
-            "type": "string",
-            "description": "Unique snippet identifier"
-          }
-        },
-        "required": [
-          "slug"
-        ]
-      },
-      "Snippet": {
-        "type": "object",
-        "properties": {
-          "json": {
-            "type": "string",
-            "nullable": true,
-            "description": "JSON input to process"
-          },
-          "http": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/HttpRequestSchema"
-              }
-            ],
-            "description": "HTTP request to fetch JSON from"
-          },
-          "query": {
-            "type": "string",
-            "minLength": 1,
-            "description": "jq query to execute"
-          },
-          "options": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Options"
-              }
-            ],
-            "description": "jq command-line options"
-          }
-        },
-        "required": [
-          "query"
-        ]
-      },
-      "SnippetCreateResponseSchema": {
-        "type": "object",
-        "properties": {
-          "slug": {
-            "type": "string",
-            "description": "Unique snippet identifier"
-          }
-        },
-        "required": [
-          "slug"
-        ]
-      },
-      "JqErrorSchema": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {}
-              }
-            ],
-            "description": "Error message or validation errors"
-          }
-        },
-        "required": [
-          "error"
-        ]
-      },
-      "JqRequest": {
+      "JqRequestSchemaOutput": {
         "type": "object",
         "properties": {
           "json": {
@@ -199,7 +176,7 @@
           "query"
         ]
       },
-      "JqResponse": {
+      "JqResponseSchema": {
         "type": "object",
         "properties": {
           "result": {
@@ -209,26 +186,6 @@
         },
         "required": [
           "result"
-        ]
-      },
-      "JqError": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {}
-              }
-            ],
-            "description": "Error message or validation errors"
-          }
-        },
-        "required": [
-          "error"
         ]
       },
       "Option": {
@@ -249,53 +206,44 @@
           "$ref": "#/components/schemas/Option"
         }
       },
-      "HttpMethodSchema": {
-        "type": "string",
-        "enum": [
-          "GET",
-          "POST",
-          "PUT",
-          "DELETE",
-          "PATCH",
-          "OPTIONS",
-          "HEAD"
-        ],
-        "description": "HTTP method"
-      },
-      "HttpHeadersSchema": {
-        "type": "string",
-        "description": "HTTP headers as JSON object string (e.g., {\"Authorization\": \"Bearer token\"})"
-      },
-      "HttpUrlSchema": {
-        "type": "string",
-        "format": "uri",
-        "description": "URL to fetch JSON from"
-      },
-      "HttpRequestSchema": {
+      "Snippet": {
         "type": "object",
         "properties": {
-          "method": {
-            "$ref": "#/components/schemas/HttpMethodSchema"
-          },
-          "url": {
-            "$ref": "#/components/schemas/HttpUrlSchema"
-          },
-          "headers": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/HttpHeadersSchema"
-              }
-            ]
-          },
-          "body": {
+          "json": {
             "type": "string",
             "nullable": true,
-            "description": "HTTP request body"
+            "description": "JSON input to process"
+          },
+          "http": {
+            "$ref": "#/components/schemas/HttpRequestSchema",
+            "description": "HTTP request to fetch JSON from",
+            "nullable": true
+          },
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "jq query to execute"
+          },
+          "options": {
+            "$ref": "#/components/schemas/Options",
+            "description": "jq command-line options",
+            "nullable": true
           }
         },
         "required": [
-          "method",
-          "url"
+          "query"
+        ]
+      },
+      "SnippetCreateResponseSchema": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Unique snippet identifier"
+          }
+        },
+        "required": [
+          "slug"
         ]
       },
       "SnippetErrorSchema": {
@@ -303,7 +251,6 @@
         "properties": {
           "error": {
             "type": "string",
-            "nullable": true,
             "description": "Error message"
           },
           "errors": {
@@ -311,10 +258,21 @@
             "items": {
               "type": "string"
             },
-            "nullable": true,
             "description": "Validation errors"
           }
         }
+      },
+      "SnippetPathParamsSchema": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Unique snippet identifier"
+          }
+        },
+        "required": [
+          "slug"
+        ]
       }
     },
     "responses": {
@@ -458,34 +416,34 @@
           {
             "in": "query",
             "name": "json",
+            "required": true,
             "schema": {
               "type": "string",
               "description": "JSON input to process (URL-encoded)",
               "example": "{\"name\": \"jq\", \"version\": \"1.7\"}"
             },
-            "required": false,
             "description": "JSON input to process (URL-encoded)"
           },
           {
             "in": "query",
             "name": "query",
+            "required": true,
             "schema": {
               "type": "string",
               "description": "jq query to execute (URL-encoded if it contains special characters like |, +, &)",
               "example": ".name"
             },
-            "required": false,
             "description": "jq query to execute (URL-encoded if it contains special characters like |, +, &)"
           },
           {
             "in": "query",
             "name": "options",
+            "required": false,
             "schema": {
               "type": "string",
               "description": "Comma-separated jq options: -c (compact), -n (null input), -R (raw input), -r (raw output), -s (slurp), -S (sort keys)",
               "example": "-r,-c"
             },
-            "required": false,
             "description": "Comma-separated jq options: -c (compact), -n (null input), -R (raw input), -r (raw output), -s (slurp), -S (sort keys)"
           }
         ],
@@ -503,10 +461,44 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/400"
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "HTTP 408",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
           }
         }
       },
@@ -541,10 +533,44 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/400"
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "HTTP 408",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JqErrorSchema"
+                }
+              }
+            }
           }
         }
       }
@@ -588,8 +614,25 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnippetErrorSchema"
+                }
+              }
+            }
+          },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnippetErrorSchema"
+                }
+              }
+            }
           }
         }
       }
@@ -606,11 +649,11 @@
           {
             "in": "path",
             "name": "slug",
+            "required": true,
             "schema": {
               "type": "string",
               "description": "Unique snippet identifier"
             },
-            "required": true,
             "description": "Unique snippet identifier",
             "example": "slug"
           }
@@ -629,11 +672,49 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnippetErrorSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnippetErrorSchema"
+                }
+              }
+            }
+          },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnippetErrorSchema"
+                }
+              }
+            }
           }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Health"
+    },
+    {
+      "name": "Jq"
+    },
+    {
+      "name": "Snippets"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Bumps the build-time OpenAPI generator `next-openapi-gen` `0.9.4` → **`1.4.3`** and regenerates `public/openapi.json`. Supersedes Dependabot **#348**.

## Notes
- **Spec is equivalent**: the regenerated `openapi.json` uses a different output format (~413 lines changed) but documents the **same 4 paths and 16 schema components**, `describe` strings preserved, valid OpenAPI 3.0.
- **gitignore** the new `.openapi-gen/` cache directory the tool creates.
- **Deprecation (follow-up)**: v1 prefers an `openapi-gen.config.ts`; the existing `next.openapi.json` still works (with a deprecation warning). Migrating the config format is left as a separate follow-up.
- A benign `JqRequestSchema` name-conflict warning is emitted during generation (handled gracefully).

## Verification
- [x] `npm audit` → 0 vulnerabilities
- [x] `tsc --noEmit` → clean
- [x] `npm run lint` → clean
- [x] `npm test` → 77/77
- [x] `npm run build` → succeeds (OpenAPI generation + build)
- [x] **`/api` Scalar docs** render the regenerated spec correctly (all endpoints, 0 console errors)