### PR TITLE
Bump jq-wasm to 2.0.0-jq-1.8.2

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,20 +8,7 @@ const nextConfig = {
     outputFileTracingIncludes: {
         '/app/api/jq/route': ['./src/workers/server/worker.cjs', './node_modules/jq-wasm/**/*'],
     },
-    webpack: (config, { isServer, webpack }) => {
-        config.resolve.fallback = {
-            fs: false,
-            path: false,
-            crypto: false
-        };
-        // jq-wasm 1.2 imports Node built-ins via the `node:` scheme; rewrite them
-        // to bare specifiers so the browser build uses the fallbacks above instead
-        // of failing on the unhandled `node:` scheme.
-        config.plugins.push(
-            new webpack.NormalModuleReplacementPlugin(/^node:(fs|path|crypto)$/, (resource) => {
-                resource.request = resource.request.replace(/^node:/, '');
-            })
-        );
+    webpack: (config, { isServer }) => {
         // Don't bundle piscina - it needs to load workers at runtime
         if (isServer) {
             config.externals = config.externals || [];

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,10 +3,16 @@ import { withSentryConfig } from '@sentry/nextjs';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: "standalone",
-    // Include packages that are dynamically loaded by piscina workers
+    // jq-wasm and piscina are loaded at runtime by the jq worker pool, not bundled.
     serverExternalPackages: ['jq-wasm', 'piscina'],
+    // Piscina loads worker.cjs from disk via a path the file tracer can't follow, so
+    // force-include it AND the jq-wasm package: jq-wasm v2 reads its wasm from a
+    // separate dist/build/jq.wasm at runtime, which the tracer won't copy on its own
+    // for an externalized package. The key must be the normalized route path
+    // (/api/jq) — Next matches these globs against routes, not the app-dir file path;
+    // the previous '/app/api/jq/route' key matched nothing, so the wasm never shipped.
     outputFileTracingIncludes: {
-        '/app/api/jq/route': ['./src/workers/server/worker.cjs', './node_modules/jq-wasm/**/*'],
+        '/api/jq': ['./src/workers/server/worker.cjs', './node_modules/jq-wasm/**/*'],
     },
     webpack: (config, { isServer }) => {
         // Don't bundle piscina - it needs to load workers at runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@sentry/nextjs": "^10.59.0",
         "@sentry/node": "^10.59.0",
         "ajv": "^8.20.0",
-        "jq-wasm": "^1.2.0-jq-1.8.2",
+        "jq-wasm": "^2.0.0-jq-1.8.2",
         "next": "^16.2.9",
         "piscina": "^5.2.0",
         "rate-limiter-flexible": "^11.2.0",
@@ -9876,10 +9876,13 @@
       }
     },
     "node_modules/jq-wasm": {
-      "version": "1.2.0-jq-1.8.2",
-      "resolved": "https://registry.npmjs.org/jq-wasm/-/jq-wasm-1.2.0-jq-1.8.2.tgz",
-      "integrity": "sha512-1DdTVvdlYFm9uc3SwmZVyQfEv8WuKWkDYZ8p4jk5jfAdL7giCO3COmb1HP2bOWgfKV2KyvkyBOgA/yeKTmdUdg==",
-      "license": "MIT"
+      "version": "2.0.0-jq-1.8.2",
+      "resolved": "https://registry.npmjs.org/jq-wasm/-/jq-wasm-2.0.0-jq-1.8.2.tgz",
+      "integrity": "sha512-0go+Mh4IZnR/cD7O/Pmh05xUP5sbPtOoOWcwUA0MH7P2NTWB3ui2tYchGS0a+N8hz4d6/i1RydghNwied1w6Aw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/js-base64": {
       "version": "3.7.8",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/nextjs": "^10.59.0",
     "@sentry/node": "^10.59.0",
     "ajv": "^8.20.0",
-    "jq-wasm": "^1.2.0-jq-1.8.2",
+    "jq-wasm": "^2.0.0-jq-1.8.2",
     "next": "^16.2.9",
     "piscina": "^5.2.0",
     "rate-limiter-flexible": "^11.2.0",

--- a/src/workers/shared/jq.ts
+++ b/src/workers/shared/jq.ts
@@ -1,4 +1,10 @@
-import { raw } from 'jq-wasm';
+// Use the inline entry point so the wasm binary is embedded in the bundle.
+// This module runs in a webpack-bundled browser web worker; the default
+// `jq-wasm` browser build loads `jq.wasm` via `new URL(..., import.meta.url)`,
+// which webpack can't reliably emit from inside a nested worker chunk. The
+// server worker (workers/server/worker.cjs) keeps the default require for the
+// lighter, file-based wasm load.
+import { raw } from 'jq-wasm/inline';
 
 export async function executeJq(
     json: string,


### PR DESCRIPTION
## Summary

Bumps `jq-wasm` from `1.2.0-jq-1.8.2` to `2.0.0-jq-1.8.2`.

v2 is a major release that drops the embedded single-file wasm build in favor of per-environment [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), shipping `jq.wasm` as a separate asset. This required adjusting how each of our two consumers loads jq-wasm — and surfaced a latent `outputFileTracingIncludes` misconfiguration.

## Changes

- **Browser web worker** (`src/workers/shared/jq.ts`): switched to the `jq-wasm/inline` entry point so the wasm binary stays embedded. The default v2 browser build loads `jq.wasm` via `new URL('./build/jq.wasm', import.meta.url)` + `fetch`, which webpack can't reliably emit from inside our nested `new Worker(new URL(...))` chunk. Inline preserves v1's single-file behavior.
- **Server worker** (`src/workers/server/worker.cjs`): left on `require('jq-wasm')`, which resolves to the Node build (`dist/index.cjs`) that reads `dist/build/jq.wasm` from disk -- the memory-lean path for the 512 MB Fly machine. Because v2 no longer embeds the wasm, this asset must be force-included in the Next standalone output (see the tracing fix below).
- **`next.config.mjs`**:
  - Removed the `node:` scheme rewrite plugin and `fs/path/crypto` webpack fallbacks. These existed solely for jq-wasm 1.x's browser build; the v2 inline build has no `node:` imports.
  - Fixed the `outputFileTracingIncludes` key from `/app/api/jq/route` to `/api/jq`. Next matches these keys against the *normalized* route path (`normalizeAppPath('app/api/jq/route')` === `/api/jq`), so the old key matched nothing and the `jq-wasm` glob force-included nothing. In v1 this was masked because the browser's `import 'jq-wasm'` incidentally pulled the embedded build into the trace, which also satisfied the server `require`; switching that import to `jq-wasm/inline` removed the incidental coverage and exposed the latent bug. Without the fix, `dist/build/jq.wasm` is absent from the standalone output and the server `/api/jq` worker fails at runtime.

## Notes

- v2 raises the Node floor to `>=20`, satisfied by the pinned Node 24 (`.node-version`).
- `raw()`'s signature is unchanged; v2 adds an `exitCode` field that we harmlessly ignore.

## Test plan

- [x] `npm run build` (exit 0, no jq-wasm/worker warnings)
- [x] `npm run lint` (clean)
- [x] `npm test` (89/89 pass -- covers both the inline browser path and the server `require` path)
- [x] Fresh **standalone** build: `dist/build/jq.wasm` is copied and the file-based server worker runs jq (`.x | add` => `10`) from the standalone's subset `node_modules`
- [x] **Browser**: playground evaluates `.nums | add` against `{"nums":[1,2,3]}` => `6`
