### PR TITLE
Upgrade jq-wasm to 3.0.0-jq-1.8.2: lean wasm loading on both jq paths

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,13 +6,12 @@ const nextConfig = {
     // jq-wasm and piscina are loaded at runtime by the jq worker pool, not bundled.
     serverExternalPackages: ['jq-wasm', 'piscina'],
     // Piscina loads worker.cjs from disk via a path the file tracer can't follow, so
-    // force-include it AND the jq-wasm package: jq-wasm v2 reads its wasm from a
-    // separate dist/build/jq.wasm at runtime, which the tracer won't copy on its own
-    // for an externalized package. The key must be the normalized route path
-    // (/api/jq) — Next matches these globs against routes, not the app-dir file path;
-    // the previous '/app/api/jq/route' key matched nothing, so the wasm never shipped.
+    // force-include it. jq-wasm is NO LONGER force-included: with v3 the worker
+    // resolves the wasm explicitly via require.resolve('jq-wasm/jq.wasm'), which puts
+    // dist/build/jq.wasm into the traced graph. The key must be the normalized route
+    // path (/api/jq) — Next matches these globs against routes, not the app-dir path.
     outputFileTracingIncludes: {
-        '/api/jq': ['./src/workers/server/worker.cjs', './node_modules/jq-wasm/**/*'],
+        '/api/jq': ['./src/workers/server/worker.cjs'],
     },
     webpack: (config, { isServer }) => {
         // Don't bundle piscina - it needs to load workers at runtime
@@ -20,6 +19,14 @@ const nextConfig = {
             config.externals = config.externals || [];
             config.externals.push('piscina');
         }
+        // Emit jq-wasm's jq.wasm as a hashed asset so the browser web worker can
+        // import its URL and hand it to loadJq({ wasmURL }) — reliable across the
+        // nested-worker-chunk boundary that new URL(import.meta.url) is not.
+        config.module.rules.push({
+            test: /jq-wasm[\\/].*\.wasm$/,
+            type: 'asset/resource',
+            generator: { filename: 'static/wasm/[hash][ext]' },
+        });
         return config;
     },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,13 +5,20 @@ const nextConfig = {
     output: "standalone",
     // jq-wasm and piscina are loaded at runtime by the jq worker pool, not bundled.
     serverExternalPackages: ['jq-wasm', 'piscina'],
-    // Piscina loads worker.cjs from disk via a path the file tracer can't follow, so
-    // force-include it. jq-wasm is NO LONGER force-included: with v3 the worker
-    // resolves the wasm explicitly via require.resolve('jq-wasm/jq.wasm'), which puts
-    // dist/build/jq.wasm into the traced graph. The key must be the normalized route
+    // Piscina loads worker.cjs from disk via a path the file tracer can't follow, and
+    // Next copies these globs verbatim — it does NOT trace the included file's own
+    // require() graph. So /api/jq must list worker.cjs AND the worker's jq-wasm
+    // runtime closure explicitly: package.json (exports-map resolution), the CJS
+    // entry, and the wasm binary. File-by-file rather than jq-wasm/** so the ~1.3MB
+    // inline builds stay out of the image. The key must be the normalized route
     // path (/api/jq) — Next matches these globs against routes, not the app-dir path.
     outputFileTracingIncludes: {
-        '/api/jq': ['./src/workers/server/worker.cjs'],
+        '/api/jq': [
+            './src/workers/server/worker.cjs',
+            './node_modules/jq-wasm/package.json',
+            './node_modules/jq-wasm/dist/index.cjs',
+            './node_modules/jq-wasm/dist/build/jq.wasm',
+        ],
     },
     webpack: (config, { isServer }) => {
         // Don't bundle piscina - it needs to load workers at runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@sentry/nextjs": "^10.59.0",
         "@sentry/node": "^10.59.0",
         "ajv": "^8.20.0",
-        "jq-wasm": "^2.0.0-jq-1.8.2",
+        "jq-wasm": "^3.0.0-jq-1.8.2",
         "next": "^16.2.9",
         "piscina": "^5.2.0",
         "rate-limiter-flexible": "^11.2.0",
@@ -9876,9 +9876,9 @@
       }
     },
     "node_modules/jq-wasm": {
-      "version": "2.0.0-jq-1.8.2",
-      "resolved": "https://registry.npmjs.org/jq-wasm/-/jq-wasm-2.0.0-jq-1.8.2.tgz",
-      "integrity": "sha512-0go+Mh4IZnR/cD7O/Pmh05xUP5sbPtOoOWcwUA0MH7P2NTWB3ui2tYchGS0a+N8hz4d6/i1RydghNwied1w6Aw==",
+      "version": "3.0.0-jq-1.8.2",
+      "resolved": "https://registry.npmjs.org/jq-wasm/-/jq-wasm-3.0.0-jq-1.8.2.tgz",
+      "integrity": "sha512-jgWSEBJSd0lYR4Q5Fw8333MxQS5jCRI+g9KwAGL7yK1spwzTJy8C5uOS08wbpKE0Gz8oQYLlRpNLE/W70Ksp2g==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/nextjs": "^10.59.0",
     "@sentry/node": "^10.59.0",
     "ajv": "^8.20.0",
-    "jq-wasm": "^2.0.0-jq-1.8.2",
+    "jq-wasm": "^3.0.0-jq-1.8.2",
     "next": "^16.2.9",
     "piscina": "^5.2.0",
     "rate-limiter-flexible": "^11.2.0",

--- a/src/workers/server/worker.cjs
+++ b/src/workers/server/worker.cjs
@@ -1,7 +1,8 @@
 // Per-worker-thread jq instance: load once, then synchronous raw() per task.
-// loadJq with an explicit require.resolve puts jq.wasm into the import graph that
-// Next's standalone file tracer follows, so no jq-wasm outputFileTracingIncludes
-// glob is needed (v2 had to force-include the whole package).
+// require.resolve finds jq.wasm wherever jq-wasm resolves at runtime; the files
+// this worker needs in the standalone build are force-included per-file via
+// outputFileTracingIncludes['/api/jq'] in next.config.mjs — Next does not trace
+// through files pulled in by those globs, so the closure is listed there.
 const { loadJq } = require('jq-wasm');
 const { readFileSync } = require('node:fs');
 

--- a/src/workers/server/worker.cjs
+++ b/src/workers/server/worker.cjs
@@ -1,6 +1,20 @@
-const jq = require('jq-wasm');
+// Per-worker-thread jq instance: load once, then synchronous raw() per task.
+// loadJq with an explicit require.resolve puts jq.wasm into the import graph that
+// Next's standalone file tracer follows, so no jq-wasm outputFileTracingIncludes
+// glob is needed (v2 had to force-include the whole package).
+const { loadJq } = require('jq-wasm');
+const { readFileSync } = require('node:fs');
+
+let jqPromise;
+function getJq() {
+    if (!jqPromise) {
+        jqPromise = loadJq({ wasmBinary: readFileSync(require.resolve('jq-wasm/jq.wasm')) });
+    }
+    return jqPromise;
+}
 
 module.exports = async function({ json, query, options }) {
-    const { stdout, stderr } = await jq.raw(json, query, options ?? undefined);
+    const jq = await getJq();
+    const { stdout, stderr } = jq.raw(json, query, options ?? undefined);
     return stdout + (stderr ? (stdout.length ? "\n" + stderr : stderr) : "");
 };

--- a/src/workers/shared/jq.ts
+++ b/src/workers/shared/jq.ts
@@ -1,16 +1,22 @@
-// Use the inline entry point so the wasm binary is embedded in the bundle.
-// This module runs in a webpack-bundled browser web worker; the default
-// `jq-wasm` browser build loads `jq.wasm` via `new URL(..., import.meta.url)`,
-// which webpack can't reliably emit from inside a nested worker chunk. The
-// server worker (workers/server/worker.cjs) keeps the default require for the
-// lighter, file-based wasm load.
-import { raw } from 'jq-wasm/inline';
+// Lean browser path: load the separate jq.wasm asset (no embedded base64).
+// webpack emits jq-wasm/jq.wasm as an asset/resource URL (see next.config.mjs),
+// which crosses the nested-worker-chunk boundary that new URL(import.meta.url)
+// does not. loadJq fetches that URL once; raw() is then synchronous.
+import { loadJq, type Jq } from 'jq-wasm';
+import wasmUrl from 'jq-wasm/jq.wasm';
+
+let jqPromise: Promise<Jq> | null = null;
+function getJq(): Promise<Jq> {
+    if (!jqPromise) jqPromise = loadJq({ wasmURL: wasmUrl });
+    return jqPromise;
+}
 
 export async function executeJq(
     json: string,
     query: string,
     options?: string[] | null
 ): Promise<string> {
-    const { stdout, stderr } = await raw(json, query, options ?? undefined);
+    const jq = await getJq();
+    const { stdout, stderr } = jq.raw(json, query, options ?? undefined);
     return stdout + (stderr ? (stdout.length ? "\n" + stderr : stderr) : "");
 }

--- a/test/jq-wasm-path.mjs
+++ b/test/jq-wasm-path.mjs
@@ -1,0 +1,9 @@
+import { fileURLToPath } from 'node:url';
+
+// vitest-only shim. At runtime the browser web worker imports `jq-wasm/jq.wasm`
+// as a webpack-emitted asset URL; under vitest (Node) there is no webpack asset
+// pipeline, so this stands in for that URL with the on-disk path to the wasm.
+// loadJq({ wasmURL }) reads it via jq-wasm's Node build, so real jq runs in tests.
+export default fileURLToPath(
+    new URL('../node_modules/jq-wasm/dist/build/jq.wasm', import.meta.url),
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,21 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+    resolve: {
+        alias: [
+            // The browser web worker (src/workers/shared/jq.ts) imports `jq-wasm/jq.wasm`
+            // as a webpack-emitted asset URL at runtime. Under vitest (Node) there is no
+            // webpack asset pipeline and Node's ESM loader chokes trying to import the
+            // binary as a module, so redirect that exact import to a shim exporting the
+            // on-disk path. loadJq({ wasmURL }) then reads it via jq-wasm's Node build —
+            // real jq still runs. Only the bare `jq-wasm/jq.wasm` asset import is affected.
+            {
+                find: /^jq-wasm\/jq\.wasm$/,
+                replacement: fileURLToPath(new URL('./test/jq-wasm-path.mjs', import.meta.url)),
+            },
+        ],
+    },
     test: {
         include: ['src/**/*.test.ts'],
         testTimeout: 10000,


### PR DESCRIPTION
## Summary

jq-wasm v3 replaces the module-level singleton with a `loadJq` factory returning a synchronous handle, and exposes the wasm binary as an addressable `jq-wasm/jq.wasm` subpath export. This PR consumes both to slim the two jq execution paths:

- **Server (`/api/jq` piscina worker):** `loadJq({ wasmBinary: readFileSync(require.resolve('jq-wasm/jq.wasm')) })`, loaded once per worker thread with synchronous `raw()` per task. The v2-era force-include of the whole package is replaced by an explicit per-file include of the worker's runtime closure (`package.json`, `dist/index.cjs`, `dist/build/jq.wasm`) — Next copies `outputFileTracingIncludes` globs without tracing through them, so the closure is listed rather than inferred. The standalone image ships 1.2 MB of jq-wasm (960 KB of it the wasm binary) instead of the entire package including two ~1.3 MB inline builds that were never executed.
- **Browser (web worker):** drops `jq-wasm/inline` (wasm embedded as base64 in the JS bundle) for `loadJq({ wasmURL })`, fed by a webpack `asset/resource` rule that emits `jq.wasm` as a hashed static asset. The wasm leaves the JS bundle and becomes a single immutable-cacheable fetch (`/_next/static/wasm/<hash>.wasm`), which also crosses the nested-worker-chunk boundary that `new URL(..., import.meta.url)` cannot.
- **Tests:** vitest aliases the `jq-wasm/jq.wasm` asset import to a shim exporting the on-disk wasm path, so worker tests keep executing real jq under Node.

## Verification

- `tsc --noEmit`, `eslint .` — clean
- `vitest run` — 7 files, 89 tests passed (real jq through both worker entry points)
- `npm run build` — clean; `.next/server/app/api/jq/route.js.nft.json` lists `worker.cjs` + the three jq-wasm closure files, so the route's trace is self-sufficient (no reliance on other routes' imports)
- Standalone server (deploy layout per Dockerfile: standalone + static + public):
  - `POST /api/jq` with `.a | add` over `{"a":[1,2,3]}` → `6` (200, `x-execution-time` header present)
  - `-r` raw output → `hello world`; invalid JSON input → jq parse error surfaced via stderr; GET query-param form → works
  - `GET /` (SSR at request time) → 200
- Browser against the standalone server (Playwright): query executed in the web worker, output editor shows `6`, `GET /_next/static/wasm/2041218713e511a5.wasm` → 200, zero console errors